### PR TITLE
Fix warnings for ComponentWillMount

### DIFF
--- a/src/SwipeActionView.ios.js
+++ b/src/SwipeActionView.ios.js
@@ -23,20 +23,26 @@ const formatButtonsMutating = buttons => {
 };
 
 export const SwipeActionView = props => {
-  formatButtonsMutating(props.leftButtons);
-  formatButtonsMutating(props.rightButtons);
+  const {leftButtons, rightButtons} = props;
+  formatButtonsMutating(leftButtons);
+  formatButtonsMutating(rightButtons);
 
   const onButtonTapped = React.useCallback(
     tappedButtonInfo => {
       const {index, side} = tappedButtonInfo.nativeEvent;
-      const buttons = props[side];
+      const buttons =
+        side === 'leftButtons'
+          ? leftButtons
+          : side === 'rightButtons'
+          ? rightButtons
+          : undefined;
       const button = buttons != null ? buttons[index] : null;
       const callback = button != null ? button.callback : null;
       if (typeof callback === 'function') {
         callback();
       }
     },
-    [props],
+    [leftButtons, rightButtons],
   );
 
   return <NativeSwipeActionView {...props} onButtonTapped={onButtonTapped} />;


### PR DESCRIPTION
* Moves from a class component to hooks (fixes componentWillMount warning)
* Removes the duplication of some props to state

I'm not sure whether it was intentional that the previous version mutated the objects in the left and right button arrays. I copied the behaviour, and highlighted it in the code. Nobody complained, and I doubt it broke anything